### PR TITLE
feat: PING-2529 uptime tracking endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "jest": "^27.0.3",
     "lint-staged": "^13.2.3",
     "nodemon": "^2.0.7",
-    "prettier": "2.8.8"
+    "prettier": "2.8.8",
+    "supertest": "^6.3.3"
   },
   "lint-staged": {
     "./**/*.{js,ts,jsx,tsx}": [

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,7 +3,9 @@ const express = require('express');
 const routing = express();
 const feed = require('./feedRoute');
 const news = require('./newsRoute');
+const statusHealthRoute = require('./status-health.route');
 
+routing.use('/status-health', statusHealthRoute);
 routing.use(`/api/v1/feed`, feed);
 routing.use(`/api/v1/news`, news);
 

--- a/src/routes/status-health.route.js
+++ b/src/routes/status-health.route.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const statusHealthService = require('../services/status-health.service');
+
+const router = express.Router();
+
+router.get('/ready', async (_req, res) => {
+  const isReady = await statusHealthService.isReady();
+  if (isReady) {
+    res.status(200).send();
+  } else {
+    res.status(503).json({message: 'Service unavailable'});
+  }
+});
+
+router.get('/live', async (_req, res) => {
+  res.status(200).send();
+});
+
+module.exports = router;

--- a/src/services/status-health.service.js
+++ b/src/services/status-health.service.js
@@ -1,0 +1,33 @@
+const {redisClient} = require('../redis/MainConfig');
+const {getDb} = require('../config/mongodb_conn');
+const postgresClient = require('./postgres/pool');
+const {sequelize} = require('../databases/models');
+
+const statusHealthService = {
+  async isReady() {
+    try {
+      await this.checkRedis();
+      await this.checkMongoDb();
+      await this.checkPostgres();
+      return true;
+    } catch (err) {
+      return false;
+    }
+  },
+  async checkRedis() {
+    // based on https://github.com/redis/ioredis/blob/9c175502b53b400a31bd8bddc8e9a469856bc820/lib/Redis.ts#L176C1-L184C1
+    await redisClient.ping();
+  },
+  async checkMongoDb() {
+    const mongoDb = await getDb();
+    await mongoDb.command({ping: 1});
+  },
+  async checkPostgres() {
+    // check our pg pool
+    await postgresClient.query('SELECT 1');
+    // check our sequelize
+    await sequelize.authenticate();
+  }
+};
+
+module.exports = statusHealthService;

--- a/src/test/routes/status-health.test.js
+++ b/src/test/routes/status-health.test.js
@@ -1,0 +1,39 @@
+const request = require('supertest');
+const express = require('express');
+const statusHealthRoute = require('../../routes/status-health.route');
+const statusHealthService = require('../../services/status-health.service');
+
+jest.mock('../../services/status-health.service', () => ({
+  isReady: jest.fn()
+}));
+
+const app = express();
+app.use('/status-health', statusHealthRoute);
+
+describe('GET /status-health/live', () => {
+  it('should return 200 OK', async () => {
+    const response = await request(app).get('/status-health/live');
+    expect(response.statusCode).toBe(200);
+  });
+});
+
+describe('GET /status-health/ready', () => {
+  afterEach(() => {
+    statusHealthService.isReady.mockReset();
+  });
+
+  it('status-health check: ready should return 200 OK', async () => {
+    statusHealthService.isReady.mockResolvedValue(true);
+
+    const response = await request(app).get('/status-health/ready');
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('status-health check: not ready should return 503 with Service unavailable response', async () => {
+    statusHealthService.isReady.mockResolvedValue(false);
+
+    const response = await request(app).get('/status-health/ready');
+    expect(response.statusCode).toBe(503);
+    expect(response.body).toEqual({message: 'Service unavailable'});
+  });
+});


### PR DESCRIPTION
1. Added `/status-health/live` endpoint to check liveness
2. Added `/status-health/ready` endpoint to check readiness (check for Redis, Mongodb and Postgres connection)
