### PR TITLE
add u1 variable to user_score and set fallback value to 1 if impr is 0

### DIFF
--- a/src/processes/scoring/calc-user-score.js
+++ b/src/processes/scoring/calc-user-score.js
@@ -38,6 +38,15 @@ const calcUserScore = async (userDoc) => {
   );
 
   // Put the calculation result in the user doc
+  userDoc.u1_variable = {
+    f,
+    b,
+    r_score: userDoc.r_score,
+    q_score: userDoc.q_score,
+    a
+  };
+  userDoc.b = b;
+  userDoc.BPpImpr_un = BPpImpr_un;
   userDoc.age_score = ageAccountUser;
   userDoc.u1_score = u1;
   userDoc.user_score = user_score;

--- a/src/utils/formula.js
+++ b/src/utils/formula.js
@@ -181,7 +181,7 @@ const blockedPerPostImpression = (blockpointsPerImpression) => {
 */
 const blockpointsPerImpression = (all_blockpoints, all_impr) => {
   if (all_impr === 0) {
-    return 0;
+    return 1;
   }
   return all_blockpoints / all_impr / USER_SCORE_WEIGHT.BP_IMPR_GLOBAL;
 };


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a new variable `u1_variable` to the user scoring system, enhancing the accuracy of user score calculations.
- Bug Fix: Adjusted the `blockpointsPerImpression` function in `formula.js` to return 1 instead of 0 when the `all_impr` parameter is 0, preventing potential division by zero errors. 
- Refactor: Updated the assignment of values to `b` and `BPpImpr_un` properties of `userDoc` for improved code clarity and maintainability.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->