### PR TITLE
feat: ping-3256 change back BP_score default to 0

### DIFF
--- a/src/processes/scoring/formula/initial-score-value.js
+++ b/src/processes/scoring/formula/initial-score-value.js
@@ -90,7 +90,7 @@ const initDataPostScore = (feedId, timestamp) => ({
   downvote_point: 0.0,
   upvote_point: 0.0,
   s_updown_score: 0.0,
-  BP_score: 1.0,
+  BP_score: 0.0,
   WS_updown_score: 0.0,
   WS_D_score: 0.0,
   WS_nonBP_score: 1.0,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: Updated the default value of the `BP_score` property in the scoring formula. The initial score for data posts has been changed from 1.0 to 0.0. This adjustment will provide a more accurate representation of the initial state of data posts in our scoring system.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->