### PR TITLE
feat: ping-3404 IMPR cannot be zero

### DIFF
--- a/src/processes/scoring/formula/initial-score-value.js
+++ b/src/processes/scoring/formula/initial-score-value.js
@@ -80,7 +80,7 @@ const initDataPostScore = (feedId, timestamp) => ({
   rec_score: 1.0, // recency score, based on expiration setting and now
   att_score: 1.0, // post-attributes score
   count_weekly_posts: 0.0, // total posts by user A (author) within last 7 days before this post
-  impr_score: 0.0,
+  impr_score: 1.0,
   domain_score: 1.0,
   longC_score: 1.0,
   p_longC_score: 1.0,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Adjusted the initial value of the `impr_score` property in the `initDataPostScore` function. This change, from 0.0 to 1.0, ensures a more accurate scoring process right from the start, enhancing the reliability of our scoring system. Users can expect improved and more consistent results when using our scoring features.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->