### PR TITLE
feat: ping-2472 reduce max limit for unfollow feed queue

### DIFF
--- a/src/config/redis.js
+++ b/src/config/redis.js
@@ -37,7 +37,7 @@ const deleteActivityProcessQueue = new Bull(QUEUE_DELETE_ACTIVITY_PROCESS, redis
 });
 const unFollowFeedProcessQueue = new Bull(QUEUE_UNFOLLOW_FEED_PROCESS, redisUrl, bullConfig, {
   limiter: {
-    max: 250,
+    max: 200,
     duration: 60 * 1000 // 60 second
   }
 });


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Adjusted the processing capacity of the `unFollowFeedProcessQueue` in our Redis configuration. The maximum limit has been reduced from 250 to 200. This change is aimed at optimizing system performance and stability, but it may slightly affect the speed of unfollowing feeds.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->