### PR TITLE
feat: ping-2703 same eslint like at user-api

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,20 +21,6 @@ module.exports = {
     ecmaVersion: 'latest'
   },
   rules: {
-    'linebreak-style': 'off',
-    'no-console': 'off',
-    'import/prefer-default-export': 'off',
-    'no-use-before-define': 'warn',
-    'no-param-reassign': 'off',
-    'react/prop-types': 'off',
-    camelcase: 'off',
-    'import/no-extraneous-dependencies': 'off',
-    'no-useless-escape': 'warn',
-    'no-nested-ternary': 'off',
-    'no-case-declarations': 'warn',
-    'comma-dangle': 'off',
-    'global-require': 'warn',
-    'no-underscore-dangle': ['error', {allow: ['_id', '_count']}], // because we use mongo and its id start with underscore
-    semi: ['error', 'always']
+    'no-unused-vars': ['error', {argsIgnorePattern: '^_', varsIgnorePattern: '^_'}]
   }
 };


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated `.eslintignore` to remove the `dist/` and `node_modules/` directories. This change simplifies the linting process by excluding unnecessary directories.
- Style: Modified `.eslintrc.js` to add a new rule that enforces the use of unused variables with names starting with an underscore. This enhances code readability and maintainability by providing a convention for unused variables.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->