### PR TITLE
feat: sync created_at data if null in mongo

### DIFF
--- a/src/processes/scoring/calc-user-score.js
+++ b/src/processes/scoring/calc-user-score.js
@@ -8,6 +8,7 @@ const {
   ageScore
 } = require('../../utils');
 const {calcKarmaScore} = require('./calc-karma-score');
+const UsersFunction = require('../../databases/functions/users');
 
 const updateLastp3Scores = (userScoreDoc, postScoreDoc) => {
   const p3scoreSubDoc = userScoreDoc.last_p3_scores[postScoreDoc._id];
@@ -54,6 +55,15 @@ const calcUserScore = async (userDoc) => {
 
   // update combined user score and karma score
   calcKarmaScore(userDoc._id, user_score);
+
+  // checking and sync date_created
+  if (userDoc.created_at === null) {
+    // if created_at is null, set it to created_at in db
+    const user = await UsersFunction.getUserByUserId(userDoc._id);
+    if (user) {
+      userDoc.created_at = user.created_at;
+    }
+  }
 
   console.debug(`calcUserScore: Final user doc: ${JSON.stringify(userDoc)}`);
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Resolved an issue where the `created_at` field in the `userDoc` object could be null. The system now checks and syncs this field, ensuring it retrieves and updates the correct timestamp from the database if initially null. This fix enhances data consistency and reliability in user scoring calculations.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->