### PR TITLE
feat: sync register_time data if null in mongo

### DIFF
--- a/src/processes/scoring/calc-user-score.js
+++ b/src/processes/scoring/calc-user-score.js
@@ -58,7 +58,7 @@ const calcUserScore = async (userDoc) => {
 
   // checking and sync date_created
   if (userDoc.created_at === null || userDoc.register_time === null) {
-    // if created_at or register_tim is null, set it to created_at in db
+    // if created_at or register_time is null, set it to created_at in db
     const user = await UsersFunction.getUserByUserId(userDoc._id);
     if (user) {
       userDoc.created_at = user.created_at;

--- a/src/processes/scoring/calc-user-score.js
+++ b/src/processes/scoring/calc-user-score.js
@@ -57,11 +57,12 @@ const calcUserScore = async (userDoc) => {
   calcKarmaScore(userDoc._id, user_score);
 
   // checking and sync date_created
-  if (userDoc.created_at === null) {
-    // if created_at is null, set it to created_at in db
+  if (userDoc.created_at === null || userDoc.register_time === null) {
+    // if created_at or register_tim is null, set it to created_at in db
     const user = await UsersFunction.getUserByUserId(userDoc._id);
     if (user) {
       userDoc.created_at = user.created_at;
+      userDoc.register_time = user.created_at;
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the user scoring process by ensuring synchronization between `created_at` and `register_time` fields in the user document. If either of these fields is null, the system now automatically retrieves the correct values from the database, improving data consistency and accuracy in user score calculations.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->