### PR TITLE
chore: reduce daily scoring intensity to every second day

### DIFF
--- a/src/processes/scoring-daily-process.js
+++ b/src/processes/scoring-daily-process.js
@@ -99,7 +99,7 @@ const onDailyProcessPostScore = async (data, job) => {
 const scoringDailyProcessJob = async (job, done) => {
   // console.log(`scoringProcessJob: ${JSON.stringify(job.data)}`);
   try {
-    console.info(`running job scoring with id: ${job.id}`);
+    console.info(`running DAILY PROCESS SCORING job with id: ${job.id}`);
     const messageData = job.data;
     let result = null;
     switch (messageData.event) {

--- a/src/queues/job-queue.js
+++ b/src/queues/job-queue.js
@@ -186,7 +186,7 @@ const initQueue = () => {
   BetterSocialCronQueue.addCron(generalDailyQueue, '0 0,12,18 * * *', 'dailyRssUpdate');
   BetterSocialCronQueue.addCron(generalDailyQueue, '0 12 * * *', 'dailyCredderUpdate');
   BetterSocialCronQueue.addCron(generalDailyQueue, '0 0 * * *', 'dailyDeleteExpiredPost');
-  BetterSocialCronQueue.addCron(generalDailyQueue, '30 11 * * *', 'dailyScoring');
+  BetterSocialCronQueue.addCron(generalDailyQueue, '30 11 */2 * *', 'dailyScoring');
   BetterSocialCronQueue.addCron(generalDailyQueue, '0 * * * *', 'refreshMaterializedView');
   BetterSocialCronQueue.addCron(generalDailyQueue, '0 8 * * *', 'topicAutoMessage');
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated the cron schedule for daily scoring in `job-queue.js` to run every second day at 11:30 instead of daily.
- Refactor: Enhanced logging message in `scoring-daily-process.js` to provide more descriptive information about the job being executed, improving debuggability and traceability.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->